### PR TITLE
Terraform unknown SetNestedAttribute panic

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -40,6 +40,7 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 func (p *frameworkProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewExampleResource,
+		NewSetUnknownResource,
 	}
 }
 

--- a/internal/provider/set_unknown_resource.go
+++ b/internal/provider/set_unknown_resource.go
@@ -1,0 +1,195 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ resource.Resource                = &SetUnknownResource{}
+	_ resource.ResourceWithImportState = &SetUnknownResource{}
+	_ resource.ResourceWithModifyPlan  = &SetUnknownResource{}
+)
+
+func NewSetUnknownResource() resource.Resource {
+	return &SetUnknownResource{}
+}
+
+type SetUnknownResource struct{}
+
+func (r *SetUnknownResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_set_unknown"
+}
+
+func (r *SetUnknownResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"set_nested_attribute": schema.SetNestedAttribute{
+				Computed: true,
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"permission": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r SetUnknownResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	var data SetUnknownResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.SetNestedAttribute = types.SetUnknown(data.SetNestedAttribute.ElementType(ctx))
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, data)...)
+}
+
+func (r SetUnknownResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data SetUnknownResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ID = types.StringValue("testing")
+
+	// Pretend the API filled in Computed attributes
+	if !data.SetNestedAttribute.IsNull() {
+		var setNestedAttributeObjects []types.Object
+
+		resp.Diagnostics.Append(data.SetNestedAttribute.ElementsAs(ctx, &setNestedAttributeObjects, false)...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		for idx, setNestedAttributeObject := range setNestedAttributeObjects {
+			if setNestedAttributeObject.IsNull() {
+				continue
+			}
+
+			var object SetNestedAttributeObjectModel
+
+			resp.Diagnostics.Append(setNestedAttributeObject.As(ctx, &object, basetypes.ObjectAsOptions{})...)
+
+			switch object.Id.ValueString() {
+			case "id-123":
+				object.Name = types.StringValue("name-123")
+			case "id-456":
+				object.Name = types.StringValue("name-456")
+			}
+
+			updatedSetNestedAttributeObject, diags := types.ObjectValueFrom(ctx, setNestedAttributeObject.AttributeTypes(ctx), object)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				continue
+			}
+
+			setNestedAttributeObjects[idx] = updatedSetNestedAttributeObject
+		}
+
+		updatedSetNestedAttribute, diags := types.SetValueFrom(ctx, data.SetNestedAttribute.ElementType(ctx), setNestedAttributeObjects)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		data.SetNestedAttribute = updatedSetNestedAttribute
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r SetUnknownResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data SetUnknownResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r SetUnknownResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data SetUnknownResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r SetUnknownResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data SetUnknownResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+}
+
+func (r SetUnknownResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+type SetUnknownResourceModel struct {
+	ID                 types.String `tfsdk:"id"`
+	SetNestedAttribute types.Set    `tfsdk:"set_nested_attribute"`
+}
+
+type SetNestedAttributeObjectModel struct {
+	Id         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Permission types.String `tfsdk:"permission"`
+}

--- a/internal/provider/set_unknown_resource_test.go
+++ b/internal/provider/set_unknown_resource_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestSetUnknownResource_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "framework_set_unknown" "test" {
+					set_nested_attribute = [
+						{
+							id = "id-123"
+							permission = "permission1"
+						},
+						{
+							id = "id-456"
+							permission = "permission2"
+						},
+					]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("framework_set_unknown.test", "id", "testing"),
+					resource.TestCheckResourceAttr("framework_set_unknown.test", "set_nested_attribute.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("framework_set_unknown.test", "set_nested_attribute.*", map[string]string{
+						"id":         "id-123",
+						"name":       "name-123",
+						"permission": "permission1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("framework_set_unknown.test", "set_nested_attribute.*", map[string]string{
+						"id":         "id-456",
+						"name":       "name-456",
+						"permission": "permission2",
+					}),
+				),
+			},
+			{
+				Config: `resource "framework_set_unknown" "test" {
+					set_nested_attribute = [
+						{
+							id = "id-456"
+							permission = "permission2"
+						},
+					]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("framework_set_unknown.test", "id", "testing"),
+					resource.TestCheckResourceAttr("framework_set_unknown.test", "set_nested_attribute.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("framework_set_unknown.test", "set_nested_attribute.*", map[string]string{
+						"id":         "id-456",
+						"name":       "name-456",
+						"permission": "permission2",
+					}),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709

```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestSetUnknownResource_basic$ github.com/bflad/terraform-provider-framework/internal/provider

--- FAIL: TestSetUnknownResource_basic (0.22s)
    /Users/bflad/src/github.com/bflad/terraform-provider-framework/internal/provider/set_unknown_resource_test.go:10: Step 1/2 error: Error running pre-apply refresh: exit status 11

        !!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

        Terraform crashed! This is always indicative of a bug within Terraform.
        Please report the crash with Terraform[1] so that we can fix this.

        When reporting bugs, please include your terraform version, the stack trace
        shown below, and any additional information which may help replicate the issue.

        [1]: https://github.com/hashicorp/terraform/issues

        !!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

        value is not known
        goroutine 78 [running]:
        runtime/debug.Stack()
        	/usr/local/go/src/runtime/debug/stack.go:24 +0x64
        runtime/debug.PrintStack()
        	/usr/local/go/src/runtime/debug/stack.go:16 +0x1c
        github.com/hashicorp/terraform/internal/logging.PanicHandler()
        	/Users/distiller/project/project/internal/logging/panic.go:55 +0x170
        panic({0x1065ae5e0, 0x106a6f0a0})
        	/usr/local/go/src/runtime/panic.go:890 +0x258
        github.com/zclconf/go-cty/cty.Value.LengthInt({{{0x106a99e78?, 0x14000c04180?}}, {0x106662b20?, 0x107e932a0?}})
        	/Users/distiller/go/pkg/mod/github.com/zclconf/go-cty@v1.12.1/cty/value_ops.go:1063 +0x218
        github.com/hashicorp/terraform/internal/plans/objchange.assertPlannedObjectValid(0x1400040de40, {{{0x0?, 0x0?}}, {0x0?, 0x0?}}, {{{0x106a99e78?, 0x14000c042b0?}}, {0x10699b560?, 0x14000655518?}}, {{{0x106a99e78?, ...}}, ...}, ...)
        	/Users/distiller/project/project/internal/plans/objchange/plan_valid.go:421 +0x418
        github.com/hashicorp/terraform/internal/plans/objchange.assertPlannedValueValid(0x140004150c0, {{{0x0?, 0x0?}}, {0x0?, 0x0?}}, {{{0x106a99e78?, 0x14000c042b0?}}, {0x10699b560?, 0x14000655518?}}, {{{0x106a99e78?, ...}}, ...}, ...)
        	/Users/distiller/project/project/internal/plans/objchange/plan_valid.go:308 +0x758
        github.com/hashicorp/terraform/internal/plans/objchange.assertPlannedAttrValid({0x14000406030, 0x14}, 0x140004150c0, {{{0x106a99e40?, 0x1400089e970?}}, {0x0?, 0x0?}}, {{{0x106a99e40?, 0x14000c042e0?}}, {0x1066907e0?, ...}}, ...)
        	/Users/distiller/project/project/internal/plans/objchange/plan_valid.go:264 +0x234
        github.com/hashicorp/terraform/internal/plans/objchange.assertPlannedAttrsValid(0x106a99e40?, {{{0x106a99e40?, 0x1400089e970?}}, {0x0?, 0x0?}}, {{{0x106a99e40?, 0x14000c042e0?}}, {0x1066907e0?, 0x140008ed1d0?}}, {{{0x106a99e40?, ...}}, ...}, ...)
        	/Users/distiller/project/project/internal/plans/objchange/plan_valid.go:249 +0x188
        github.com/hashicorp/terraform/internal/plans/objchange.assertPlanValid(0x140004093b0, {{{0x106a99e40?, 0x1400089e970?}}, {0x0?, 0x0?}}, {{{0x106a99e40?, 0x14000c042e0?}}, {0x1066907e0?, 0x140008ed1d0?}}, {{{0x106a99e40?, ...}}, ...}, ...)
        	/Users/distiller/project/project/internal/plans/objchange/plan_valid.go:57 +0x2ac
        github.com/hashicorp/terraform/internal/plans/objchange.AssertPlanValid(...)
        	/Users/distiller/project/project/internal/plans/objchange/plan_valid.go:36
        github.com/hashicorp/terraform/internal/terraform.(*NodeAbstractResourceInstance).plan(0x140001603c0, {0x106aaf6f8, 0x140009e4380}, 0x0, 0x0, 0x0, {0x0, 0x0, 0x0?})
        	/Users/distiller/project/project/internal/terraform/node_resource_abstract_instance.go:830 +0x153c
        github.com/hashicorp/terraform/internal/terraform.(*NodePlannableResourceInstance).managedResourceExecute(0x1400064f940, {0x106aaf6f8, 0x140009e4380})
        	/Users/distiller/project/project/internal/terraform/node_resource_plan_instance.go:223 +0xa6c
        github.com/hashicorp/terraform/internal/terraform.(*NodePlannableResourceInstance).Execute(0x0?, {0x106aaf6f8?, 0x140009e4380?}, 0x80?)
        	/Users/distiller/project/project/internal/terraform/node_resource_plan_instance.go:60 +0x7c
        github.com/hashicorp/terraform/internal/terraform.(*ContextGraphWalker).Execute(0x140009ea0f0, {0x106aaf6f8, 0x140009e4380}, {0x11001f230, 0x1400064f940})
        	/Users/distiller/project/project/internal/terraform/graph_walk_context.go:136 +0xa8
        github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1({0x106a1aec0, 0x1400064f940})
        	/Users/distiller/project/project/internal/terraform/graph.go:75 +0x238
        github.com/hashicorp/terraform/internal/dag.(*Walker).walkVertex(0x1400081e600, {0x106a1aec0, 0x1400064f940}, 0x1400064fa40)
        	/Users/distiller/project/project/internal/dag/walk.go:381 +0x2e0
        created by github.com/hashicorp/terraform/internal/dag.(*Walker).Update
        	/Users/distiller/project/project/internal/dag/walk.go:304 +0xbf0
FAIL
FAIL	github.com/bflad/terraform-provider-framework/internal/provider	1.002s
FAIL
```